### PR TITLE
Fix: [기능] #53 plan로직 추가,  memberStore 수정

### DIFF
--- a/src/pages/plan/Plan.tsx
+++ b/src/pages/plan/Plan.tsx
@@ -8,6 +8,7 @@ import styles from "./Plan.module.css";
 import axios from "axios";
 import PlanModify from "./include/PlanModify";
 import usePlanStore from "../../stores/PlanStore";
+import useMemberStore from "../../stores/MemberStore";
 import { API_BASE_URL } from "../../config";
 import AlertModal from "../../components/modal/AlertModal";
 
@@ -83,6 +84,7 @@ const Plan: React.FC<{ planId?: number }> = ({ planId }) => {
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [message, setMessage] = useState<string>("");
+  const memberStore = useMemberStore();
 
   const [plan, setPlan] = useState<planInterface>({
     name: "",
@@ -190,14 +192,40 @@ const Plan: React.FC<{ planId?: number }> = ({ planId }) => {
   };
 
   // 모달 열기
-  const handleSaveClick = () => {
+  const handleSaveClick = async () => {
     setModalOpen(true);
   };
 
   // 모달 안에서 저장 버튼 클릭했을때
-  const handleModalConfirm = () => {
+  const handleModalConfirm = async () => {
     setModalOpen(false);
     // 저장 로직 추가
+    // plan의 concepts와 companion_count를 문자열로 직렬화
+    const concepts = JSON.stringify(plan.concepts);
+    const companion_count = JSON.stringify(plan.companion_count);
+    try {
+      const response = await axios.post(`${API_BASE_URL}/plans`, {
+        plan: {
+          ...plan,
+          concepts,
+          companion_count,
+        },
+
+        spots: spots,
+        // TODO: HTTPS 환경에서 쿠키로 전달하게끔 변경해야 함.
+        // 현재는 HTTP환경이라 POST요청시 HttpOnly 쿠키가 전달되지 않아 임시방편임.
+        email: memberStore.getMemberInfo().email,
+        withCredentials: true,
+      });
+      console.log("savePlanData", response.data);
+      setMessage("일정 저장 완료");
+
+      setIsOpen(true);
+    } catch (err) {
+      console.error(err);
+      setMessage("일정 저장 중 오류가 발생했습니다. 잠시후 다시 시도해주세요");
+      setIsOpen(true);
+    }
   };
 
   // 모달 닫기
@@ -281,7 +309,12 @@ const Plan: React.FC<{ planId?: number }> = ({ planId }) => {
         content={message}
         onConfirm={() => {
           setIsOpen(false);
-          navigate("/plan/filter/selector");
+          if (
+            message !==
+            "일정 저장 중 오류가 발생했습니다. 잠시후 다시 시도해주세요"
+          ) {
+            navigate("/plan/filter/selector");
+          }
         }}
       />
     </>

--- a/src/stores/MemberStore.tsx
+++ b/src/stores/MemberStore.tsx
@@ -12,6 +12,7 @@ interface MemberInfo {
 // 스토어 객체 interface
 interface MemberStore {
   memberInfo: MemberInfo;
+  getMemberInfo: () => MemberInfo;
   setMemberInfo: (memberInfo: MemberInfo) => void;
   // 익명 사용자 여부 확인
   isAnonymous: () => boolean;
@@ -29,6 +30,7 @@ const useMemberStore: any = create(
         profile_url: "",
         roles: [],
       },
+      getMemberInfo: () => get().memberInfo,
       setMemberInfo: (newMemberInfo: MemberInfo) =>
         set({ memberInfo: newMemberInfo }),
 


### PR DESCRIPTION
### 일정 저장을 위한 로직을 추가했습니다.
- 에이전트가 초기 일정을 전달하고 저장 모달의 확인버튼을 누르면 백엔드에 저장 API를 요청하도록 했습니다.
- 추후 HTTPS가 도입되면 해당 로직에 수정이 필요합니다.