### PR TITLE
Fix: [기능] 일정 수정 시 PlanStorage초기화 문제 수정, spot 스키마 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-calendar": "^5.1.0",
         "react-dom": "^18.3.1",
         "react-icons": "^5.4.0",
-        "react-router-dom": "^7.1.4",
+        "react-router-dom": "^7.1.5",
         "react-scripts": "5.0.1",
         "react-slick": "^0.30.3",
         "slick-carousel": "^1.8.1",
@@ -14864,6 +14864,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
       "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
+      "license": "MIT",
       "dependencies": {
         "react-router": "7.1.5"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-calendar": "^5.1.0",
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
-    "react-router-dom": "^7.1.4",
+    "react-router-dom": "^7.1.5",
     "react-scripts": "5.0.1",
     "react-slick": "^0.30.3",
     "slick-carousel": "^1.8.1",

--- a/src/components/modal/PromptModal.tsx
+++ b/src/components/modal/PromptModal.tsx
@@ -10,18 +10,15 @@ import ConfirmModal from "./ConfirmModal";
 import AlertModal from "./AlertModal";
 
 interface spotInterface {
-  latitude: number;
-  longitude: number;
   kor_name: string;
   eng_name: string;
   description: string;
   address: string;
-  zip: string;
   url: string;
   image_url: string;
   map_url: string;
-  likes: number;
-  satisfaction: number;
+  latitude: number;
+  longitude: number;
   spot_category: number;
   phone_number: string;
   business_status: boolean;

--- a/src/pages/main/home.tsx
+++ b/src/pages/main/home.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import ShortBtn from "../../components/buttons/ShortBtn";
 import MainSlider from "./MainSlider";
 import "./home.css";
+import usePlanStore from "../../stores/PlanStore"
 
 const Home: React.FC = () => {
   const navigate = useNavigate();
@@ -24,7 +25,10 @@ const Home: React.FC = () => {
           <div className="travel-plan-button">
             <ShortBtn
               content="텍스트로 시작"
-              onClick={() => navigate("/plan/filter")}
+              onClick={() => {
+                usePlanStore.getState().initPlanInfo();
+                navigate("/plan/filter")
+              }}
             />
           </div>
         </div>

--- a/src/pages/plan/Plan.tsx
+++ b/src/pages/plan/Plan.tsx
@@ -17,18 +17,15 @@ import PlanMap from "./include/PlanMap";
 import TimeBar from "./include/TimeBar";
 
 interface spotResponse {
-  latitude: number;
-  longitude: number;
   kor_name: string;
   eng_name: string;
   description: string;
   address: string;
-  zip: string;
   url: string;
   image_url: string;
   map_url: string;
-  likes: number;
-  satisfaction: number;
+  latitude: number;
+  longitude: number;
   spot_category: number;
   phone_number: string;
   business_status: boolean;
@@ -147,7 +144,6 @@ const Plan: React.FC = () => {
       setIsOpen(true);
     } finally {
       setIsLoading(false);
-      planStore.initPlanInfo();
     }
   };
 

--- a/src/pages/plan/include/PlanDetail.tsx
+++ b/src/pages/plan/include/PlanDetail.tsx
@@ -4,18 +4,15 @@ import SpotDetail from "../../../components/modal/SpotDetail";
 import TimeBar from "./TimeBar";
 
 interface spotResponse {
-  latitude: number;
-  longitude: number;
   kor_name: string;
   eng_name: string;
   description: string;
   address: string;
-  zip: string;
   url: string;
   image_url: string;
   map_url: string;
-  likes: number;
-  satisfaction: number;
+  latitude: number;
+  longitude: number;
   spot_category: number;
   phone_number: string;
   business_status: boolean;

--- a/src/pages/plan/include/PlanMap.tsx
+++ b/src/pages/plan/include/PlanMap.tsx
@@ -3,18 +3,15 @@ import LoadKakaoMap from "./LoadPlanMap";
 
 // Plan.tsx 등에서 사용하는 동일한 spotResponse 타입
 interface spotResponse {
-  latitude: number;
-  longitude: number;
   kor_name: string;
   eng_name: string;
   description: string;
   address: string;
-  zip: string;
   url: string;
   image_url: string;
   map_url: string;
-  likes: number;
-  satisfaction: number;
+  latitude: number;
+  longitude: number;
   spot_category: number;
   phone_number: string;
   business_status: boolean;
@@ -24,7 +21,6 @@ interface spotResponse {
   spot_time: string;
   drivingTime?: string;
 }
-
 // PlanMap 컴포넌트 Props
 interface PlanMapProps {
   spots: spotResponse[];

--- a/src/pages/plan/include/PlanModify.tsx
+++ b/src/pages/plan/include/PlanModify.tsx
@@ -13,18 +13,15 @@ import SpotDetail from "../../../components/modal/SpotDetail";
 import AlertModal from "../../../components/modal/AlertModal";
 
 interface spotResponse {
-  latitude: number;
-  longitude: number;
   kor_name: string;
   eng_name: string;
   description: string;
   address: string;
-  zip: string;
   url: string;
   image_url: string;
   map_url: string;
-  likes: number;
-  satisfaction: number;
+  latitude: number;
+  longitude: number;
   spot_category: number;
   phone_number: string;
   business_status: boolean;


### PR DESCRIPTION
1. 일정 수정시 PlanStorage가 초기화 되어 input_data 없는 문제 수정
- 기존 : 일정 생성 완료 후 PlanStorage초기화
- 변경 : 일정 생성 시작 시(텍스트 시작 버튼 누를 시점) PlanStorage초기화

3. spot interface 변경
- 삭제 : 우편번호, 좋아요, 만족도
- 추가 : 위도, 경도