### PR TITLE
[기능] URL로 Plans페이지 직접 접근 방지, 초안 에이전트 호출로 변경, http 요청 취소 버튼 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,10 @@ import Unauthorized from "./pages/error/Unauthorized";
 import InternalServerError from "./pages/error/InternalServerError";
 import "./firebase-config";
 import LoginCheck from "./components/intercept/loginCheck";
+import { useState } from "react";
 
 function App() {
+  const [newRequest, setNewRequest] = useState<boolean>(false);
   return (
     <div>
       <LoadKakaoMap />
@@ -34,9 +36,15 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/loginform" element={<LoginForm />} />
             <Route path="/hj" element={<HjWebTest />} />
-            <Route path="/plan/filter/" element={<PlanFilter />} />
+            <Route
+              path="/plan/filter/"
+              element={<PlanFilter changeRequestState={setNewRequest} />}
+            />
             <Route path="/plans/list" element={<PlanList />} />
-            <Route path="/plans/:planIdFirst?" element={<Plan />} />
+            <Route
+              path="/plans/:planIdFirst?"
+              element={<Plan newRequest={newRequest} />}
+            />
             <Route path="/checkList" element={<CheckList />} />
             <Route path="/minigame" element={<MiniGame />} />{" "}
             {/* MiniGame 경로 추가 */}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
 //로컬 환경(테스트 용)
-// export const API_BASE_URL = "http://127.0.0.1:8000"; // 로컬 주소
-// export const CLIENT_CALLBACK_URL = "http://localhost:3000/loginForm"; // 클라이언트 콜백 주소
+export const API_BASE_URL = "http://127.0.0.1:8000"; // 로컬 주소
+export const CLIENT_CALLBACK_URL = "http://localhost:3000/loginForm"; // 클라이언트 콜백 주소
 
 //EC2 환경(배포용)
-export const API_BASE_URL = "https://api-easytravel.jomalang.com"; // EC2 주소
-export const CLIENT_CALLBACK_URL = "https://easytravel.jomalang.com/loginForm"; // EC2 클라이언트 콜백 주소
+// export const API_BASE_URL = "https://api-easytravel.jomalang.com"; // EC2 주소
+// export const CLIENT_CALLBACK_URL = "https://easytravel.jomalang.com/loginForm"; // EC2 클라이언트 콜백 주소
 
 export const GOOGLE_CLIENT_ID =
   "638525891124-pphosnugos63hd2khdrrf96tjjh9r4q3.apps.googleusercontent.com";

--- a/src/pages/plan/Plan.module.css
+++ b/src/pages/plan/Plan.module.css
@@ -42,7 +42,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  background-color: var(--black-opacity-25);
+  background-color: var(--black-opacity-50);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -166,5 +166,29 @@
   height: 100%;
   min-height: 100vh;
   padding: 0 12px;
+}
+
+.cancel_request_btn {
+  margin-top: 20px;
+  padding: 10px 20px;
+  background-color: var(--black-opacity-50);
+  color: var(--white);
+  border: none;
+  border-radius: var(--border-radius-2);
+  font-size: var(--font-size-5);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.cancel_request_btn:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+@media (max-width: 768px) {
+  .cancel_request_btn {
+    font-size: var(--font-size-6);
+    padding: 8px 16px;
+  }
 }
 

--- a/src/pages/plan/Plan.tsx
+++ b/src/pages/plan/Plan.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import LongBtn from "../../components/buttons/LongBtn";
 import ConfirmModal from "../../components/modal/ConfirmModal"; // 모달 컴포넌트
@@ -11,7 +11,7 @@ import useMemberStore from "../../stores/MemberStore";
 import { API_BASE_URL } from "../../config";
 import AlertModal from "../../components/modal/AlertModal";
 import PlanDetail from "./include/PlanDetail";
-import AgentSelectModal from "../../components/modal/AgentSelectModal";
+// import AgentSelectModal from "../../components/modal/AgentSelectModal";
 import { List } from "lucide-react";
 import PlanMap from "./include/PlanMap";
 import MiniGame from "../minigame/MiniGame";
@@ -68,7 +68,7 @@ const generateDaysArray = (startDate: Date, endDate: Date) => {
   return daysArray;
 };
 
-const Plan: React.FC = () => {
+const Plan: React.FC<{ newRequest: boolean }> = ({ newRequest }) => {
   const [currentTab, setCurrentTab] = useState<string>("detail");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false);
@@ -102,59 +102,88 @@ const Plan: React.FC = () => {
   };
 
   // 에이전트 선택 후 일정 생성 관련 상태
-  const [showAgentModal, setShowAgentModal] = useState<boolean>(true);
+  // const [showAgentModal, setShowAgentModal] = useState<boolean>(true);
+  const [abortController, setAbortController] =
+    useState<AbortController | null>(null);
 
   // 일정 목록 페이지로 이동
   const handleListClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     navigate("/plans/list");
   };
-  // 에이전트 선택 및 요청
-  const handleAgentSelect = async (agentType: string[]) => {
-    setShowAgentModal(false);
-    setIsLoading(true);
-    try {
-      let planData = planStore.getPlan();
+  // 에이전트 선택 및 요청 (인자에 agentType: string[] 포함.)
+  //에이전트 요청
+  useEffect(() => {
+    const handleAgentSelect = async () => {
+      //올바른 방식로 접근한게 아니라면 홈으로 이홈
+      if (newRequest === false) {
+        navigate("/");
+      }
 
-      // email 추가한 새로운 객체 생성
-      const planDataWithEmail = {
-        ...planData, // 기존 데이터 유지
-        email: memberStore.getMemberInfo().email,
-      };
+      // 이전 요청이 있다면 취소
+      if (abortController) {
+        abortController.abort();
+      }
 
-      // 화면에 출력하기 위한 형식 변환
-      const planDataforPrint = {
-        name: planData.name,
-        start_date: new Date(planData.start_date),
-        end_date: new Date(planData.end_date),
-        main_location: planData.main_location,
-        ages: planData.ages,
-        companion_count: planData.companion_count,
-        concepts: planData.concepts,
-      };
-      setPlan(planDataforPrint);
-      // agentType 포함 API 요청
-      const response = await axios.post(
-        `${API_BASE_URL}/agents/plan`,
-        planDataWithEmail,
-        {
-          params: {
-            agent_type: agentType,
-          },
-          withCredentials: true,
+      // 새로운 AbortController 생성
+      const controller = new AbortController();
+      setAbortController(controller);
+
+      // setShowAgentModal(false);
+      setIsLoading(true);
+      try {
+        let planData = planStore.getPlan();
+
+        // email 추가한 새로운 객체 생성
+        const planDataWithEmail = {
+          ...planData, // 기존 데이터 유지
+          email: memberStore.getMemberInfo().email,
+        };
+
+        // 화면에 출력하기 위한 형식 변환
+        const planDataforPrint = {
+          name: planData.name,
+          start_date: new Date(planData.start_date),
+          end_date: new Date(planData.end_date),
+          main_location: planData.main_location,
+          ages: planData.ages,
+          companion_count: planData.companion_count,
+          concepts: planData.concepts,
+        };
+        setPlan(planDataforPrint);
+
+        // agentType 포함 API 요청
+        const response = await axios.post(
+          `${API_BASE_URL}/agents/plan`,
+          planDataWithEmail,
+          {
+            // params: {
+            //   agent_type: agentType,
+            // },
+            withCredentials: true,
+            signal: controller.signal, // AbortController의 signal 사용
+          }
+        );
+
+        const spotInfos = response.data.data.spots.spots;
+        setSpots(spotInfos);
+      } catch (err) {
+        if (axios.isCancel(err)) {
+          console.log("Request aborted:", err.message);
+        } else {
+          console.error("에이전트 요청 중 오류 발생:", err);
+          setMessage(
+            "일정 생성 중 오류가 발생했습니다. 잠시후 다시 시도해주세요"
+          );
+          setIsOpen(true);
         }
-      );
-
-      const spotInfos = response.data.data.spots.spots;
-      setSpots(spotInfos);
-    } catch (err) {
-      console.error("에이전트 요청 중 오류 발생:", err);
-      setMessage("일정 생성 중 오류가 발생했습니다. 잠시후 다시 시도해주세요");
-      setIsOpen(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      } finally {
+        setIsLoading(false);
+        setAbortController(null);
+      }
+    };
+    handleAgentSelect();
+  }, []);
 
   // 저장된 일정 조회용
   const fetchPlanData = async () => {
@@ -352,6 +381,26 @@ const Plan: React.FC = () => {
     }
   };
 
+  // 요청 취소 핸들러
+  const handleCancelRequest = () => {
+    if (abortController) {
+      abortController.abort();
+      setIsLoading(false);
+      setMessage("요청이 취소되었습니다.");
+      setIsOpen(true);
+      navigate("/plan/filter");
+    }
+  };
+
+  // 컴포넌트 언마운트 시 요청 취소
+  useEffect(() => {
+    return () => {
+      if (abortController) {
+        abortController.abort();
+      }
+    };
+  }, [abortController]);
+
   return (
     <div className={styles.travel_plan_container}>
       <div className={styles.travel_plan_tab_container}>
@@ -405,8 +454,15 @@ const Plan: React.FC = () => {
 
         {isLoading ? (
           <div className={styles.loading_container}>
-            <MiniGame />
             <p>AI가 여행 일정을 생성하고 있습니다...</p>
+            <p>일을 마치면 알림으로 알려드려요!</p>
+            <MiniGame />
+            <button
+              className={styles.cancel_request_btn}
+              onClick={handleCancelRequest}
+            >
+              요청 취소
+            </button>
           </div>
         ) : isDataLoaded ? (
           <>
@@ -453,10 +509,10 @@ const Plan: React.FC = () => {
         ) : null}
       </div>
 
-      <AgentSelectModal
+      {/* <AgentSelectModal
         isOpen={showAgentModal && !planId}
         onSelect={handleAgentSelect}
-      />
+      /> */}
 
       <ConfirmModal
         isOpen={isModalOpen}

--- a/src/pages/plan/PlanFilter.tsx
+++ b/src/pages/plan/PlanFilter.tsx
@@ -3,7 +3,15 @@ import { useNavigate } from "react-router-dom";
 import Calendar, { CalendarProps } from "react-calendar";
 import LongBtn from "../../components/buttons/LongBtn";
 import NormalInput2 from "../../components/input/NormalInput2";
-import { Cloud, Sun, CloudRain, AlertCircle } from "lucide-react";
+import {
+  Cloudy,
+  Cloud,
+  Sun,
+  CloudRain,
+  AlertCircle,
+  Snowflake,
+  Umbrella,
+} from "lucide-react";
 import { API_BASE_URL } from "../../config";
 import axios from "axios";
 import usePlanStore from "../../stores/PlanStore";
@@ -14,7 +22,14 @@ import styles from "./PlanFilter.module.css";
 import AlertModal from "../../components/modal/AlertModal";
 
 // 가능한 날씨 상태
-type WeatherType = "맑음" | "흐림" | "비";
+type WeatherType =
+  | "맑음"
+  | "구름많음"
+  | "흐림"
+  | "비/눈"
+  | "비"
+  | "눈"
+  | "소나기";
 
 // 날씨 상태 인터페이스 (나중에 API 연동 시 사용할 error 옵션 포함)
 interface WeatherState {
@@ -28,6 +43,7 @@ interface DateSelectorProps {
   setSelectedDateRange: React.Dispatch<
     React.SetStateAction<[Date, Date] | null>
   >;
+  setStart_date: (date: Date) => void;
 }
 
 // 일행 인터페이스
@@ -38,29 +54,46 @@ interface Companion {
 
 const ages = ["10대", "20대", "30대", "40대", "50대", "60대", "70대", "80대"];
 
-const purposes = [
+const accomodation_concept = [
   "호캉스",
-  "수영장",
-  "혼자",
-  "기념일",
   "리조트",
-  "맛집",
+  "캠핑",
+  "글램핑",
+  "한옥",
+  "풀빌라",
+  "게스트 하우스",
+];
+
+const site_concept = [
+  "기념일",
+  "역사",
+  "자연",
+  "예술",
+  "도시",
+  "전통",
   "바다",
-  "낮술",
   "산",
+  "가족",
+  "데이트",
   "힐링",
-  "카페 투어",
-  "장수 잔치",
-  "가족 여행",
-  "해산물 좋아",
-  "고기 좋아",
-  "역사 여행",
+];
+
+const restaurant_concept = ["낮술", "해산물", "고기", "채식", "브런치"];
+
+const cafe_concept = ["모던 카페", "야외 카페", "감성 카페", "느좋 카페"];
+
+const purposes = [
+  ...accomodation_concept,
+  ...site_concept,
+  ...restaurant_concept,
+  ...cafe_concept,
 ];
 
 // 일정(달력) 컴포넌트
 const DateSelector: React.FC<DateSelectorProps> = ({
   selectedDateRange,
   setSelectedDateRange,
+  setStart_date,
 }) => {
   const [activeStartDate, setActiveStartDate] = useState<Date>(new Date()); // 현재 활성화된 달 상태
 
@@ -68,6 +101,7 @@ const DateSelector: React.FC<DateSelectorProps> = ({
   const handleDateChange: CalendarProps["onChange"] = (value) => {
     if (Array.isArray(value) && value.length === 2) {
       setSelectedDateRange(value as [Date, Date]);
+      setStart_date(value[0] as Date);
     }
   };
 
@@ -145,7 +179,14 @@ const DateSelector: React.FC<DateSelectorProps> = ({
 };
 
 // 날씨 정보 컴포넌트
-const WeatherAlert = () => {
+const WeatherAlert: React.FC<{
+  selectedX: number | null;
+  selectedY: number | null;
+  start_date: string;
+}> = ({ selectedX, selectedY, start_date }) => {
+  const url =
+    "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst";
+  const WEATHER_API_KEY = process.env.REACT_APP_WEATHER_API_KEY;
   // 기본 날씨 상태 설정 (error, setWeatherState는 API 연동 전까지는 불필요)
   const [weatherState, setWeatherState] = useState<WeatherState>({
     type: "맑음",
@@ -158,7 +199,15 @@ const WeatherAlert = () => {
         return <Sun className={styles.weather_icon} />;
       case "흐림":
         return <Cloud className={styles.weather_icon} />;
+      case "구름많음":
+        return <Cloudy className={styles.weather_icon} />;
       case "비":
+        return <Umbrella className={styles.weather_icon} />;
+      case "눈":
+        return <Snowflake className={styles.weather_icon} />;
+      case "소나기":
+        return <CloudRain className={styles.weather_icon} />;
+      case "비/눈":
         return <CloudRain className={styles.weather_icon} />;
       default:
         return (
@@ -168,6 +217,86 @@ const WeatherAlert = () => {
         );
     }
   };
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      try {
+        const base_date = start_date.split("-").join("");
+        const response = await axios.get(url, {
+          params: {
+            serviceKey: WEATHER_API_KEY,
+            pageNo: 1,
+            numOfRows: 11,
+            dataType: "JSON",
+            base_date: base_date,
+            base_time: "1400",
+            nx: selectedX,
+            ny: selectedY,
+          },
+        });
+        console.log(response.data.response.body.items.item);
+        if (response.data.response.body.items.item) {
+          const weatherDatas = response.data.response.body.items.item;
+          const skyData = weatherDatas.filter(
+            (data: any) => data.category === "SKY"
+          );
+          const rainData = weatherDatas.filter(
+            (data: any) => data.category === "PTY"
+          );
+          console.log(skyData);
+          console.log(rainData);
+
+          if (rainData && rainData[0].obsrValue === 0) {
+            switch (skyData[0].obsrValue) {
+              case "1":
+                setWeatherState({
+                  type: "맑음",
+                });
+                break;
+              case "3":
+                setWeatherState({
+                  type: "구름많음",
+                });
+                break;
+              case "4":
+                setWeatherState({
+                  type: "흐림",
+                });
+                break;
+            }
+          } else {
+            switch (rainData[0].obsrValue) {
+              case "1":
+                setWeatherState({
+                  type: "비",
+                });
+                break;
+              case "2":
+                setWeatherState({
+                  type: "비/눈",
+                });
+                break;
+              case "3":
+                setWeatherState({
+                  type: "눈",
+                });
+                break;
+              case "4":
+                setWeatherState({
+                  type: "소나기",
+                });
+                break;
+            }
+          }
+        }
+
+        console.log(weatherState);
+      } catch (error) {
+        console.error("날씨 데이터 가져오기 실패:", error);
+      }
+    };
+    fetchWeatherData();
+  }, [selectedX, selectedY, start_date]);
 
   return (
     <div className={styles.weather_container}>
@@ -180,7 +309,7 @@ const WeatherAlert = () => {
             예상 날씨 - {weatherState.type}
           </h3>
           <p className={styles.weather_update_time}>
-            3일 전 알람으로 다시 알려드릴게요!
+            {start_date} 기준 날씨 정보입니다.
           </p>
         </div>
       </div>
@@ -188,7 +317,9 @@ const WeatherAlert = () => {
   );
 };
 
-const PlanFilterSelector: React.FC = () => {
+const PlanFilterSelector: React.FC<{
+  changeRequestState: (newRequest: boolean) => void;
+}> = ({ changeRequestState }) => {
   const navigate = useNavigate();
   const setPlan = usePlanStore((state) => state.setPlan);
 
@@ -206,6 +337,15 @@ const PlanFilterSelector: React.FC = () => {
   const [filteredRegions, setFilteredRegions] = useState<any[]>([]); // 필터링된 지역 리스트
   const [selectedAge, setSelectedAge] = useState<string | null>(null); // 나이
   const [selectedPurposes, setSelectedPurposes] = useState<string[]>([]); // 목적
+  const [selectedX, setSelectedX] = useState<number | null>(60); // 날씨 api x좌표 기본값 서울 특별시
+  const [selectedY, setSelectedY] = useState<number | null>(127); // 날씨 api y좌표 기본값 서울 특별시
+  const [start_date, setStart_date] = useState<string>(() => {
+    const today = new Date();
+    return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(
+      2,
+      "0"
+    )}-${String(today.getDate()).padStart(2, "0")}`;
+  }); // 날씨 api 시작일
 
   // 매핑 테이블
   const provinceMappings: Record<string, string> = {
@@ -230,6 +370,11 @@ const PlanFilterSelector: React.FC = () => {
     }
   };
 
+  // 날짜 변경 이벤트 핸들러
+  const handleStart_date = (date: Date) => {
+    setStart_date(date.toISOString().split("T")[0]);
+  };
+
   // 사용자가 입력한 값에 따라 필터링
   const handleRegionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -251,8 +396,10 @@ const PlanFilterSelector: React.FC = () => {
   };
 
   // 사용자가 리스트에서 지역 선택 시 상태 저장
-  const handleRegionSelect = (selectedRegion: string) => {
+  const handleRegionSelect = (selectedRegion: string, x: number, y: number) => {
     setRegion(selectedRegion);
+    setSelectedX(x);
+    setSelectedY(y);
     setFilteredRegions([]); // 리스트 초기화
   };
 
@@ -348,6 +495,8 @@ const PlanFilterSelector: React.FC = () => {
       });
 
       // 플랜 페이지로 이동
+      // 올바른 과정임을 알림
+      changeRequestState(true);
       navigate("/plans/");
     } catch (error) {
       console.error("데이터 저장 중 오류 발생:", error);
@@ -394,7 +543,9 @@ const PlanFilterSelector: React.FC = () => {
                   handleRegionSelect(
                     filteredRegion.city_province === filteredRegion.city_county
                       ? filteredRegion.city_province // 광역시는 중복 제거
-                      : `${filteredRegion.city_province} - ${filteredRegion.city_county}`
+                      : `${filteredRegion.city_province} - ${filteredRegion.city_county}`,
+                    filteredRegion.x_position,
+                    filteredRegion.y_position
                   )
                 }
               >
@@ -411,10 +562,15 @@ const PlanFilterSelector: React.FC = () => {
       <DateSelector
         selectedDateRange={selectedDateRange}
         setSelectedDateRange={setSelectedDateRange}
+        setStart_date={handleStart_date}
       />
 
       {/* 날씨 정보 */}
-      <WeatherAlert />
+      <WeatherAlert
+        selectedX={selectedX}
+        selectedY={selectedY}
+        start_date={start_date}
+      />
 
       {/* 나이 선택 */}
       <div className={styles.travel_age_section}>


### PR DESCRIPTION
1. URL을 이용해 Plans 페이지에 직접 접근하는 일을 막았습니다. app컴포넌트 수준에서 `useState`를 이용합니다.
2. 이제 filter에서 확인을 누르면 다시 초안 에이전트를 호출하도록 했습니다. (에이전트 선택 모달을 없애고, 요청에 쿼리 파라미터를 제거했습니다.)
3. 요청간 http 요청 취소 버튼을 추가했습니다. 그런데 이 기능이 제대로 동작하기 위해선 백엔드에서 동작중인 에이전트를 멈추는 기능까지 구현해야 합니다. 지금으로서 취소버튼을 누르면, **하나의 에이전트가 그 순간 요청하던 특정한 http 요청 하나만을 취소하게 되**고 전체 과정이 취소되진 않습니다.