### PR TITLE
Fix:기존 일정은 설문 모달 건너뛰도록 프론트 로직 수정

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 //로컬 환경(테스트 용)
-//export const API_BASE_URL = "http://127.0.0.1:8000"; // 로컬 주소
-//export const CLIENT_CALLBACK_URL = "http://localhost:3000/loginForm"; // 클라이언트 콜백 주소
+// export const API_BASE_URL = "http://127.0.0.1:8000"; // 로컬 주소
+// export const CLIENT_CALLBACK_URL = "http://localhost:3000/loginForm"; // 클라이언트 콜백 주소
 
 //EC2 환경(배포용)
 export const API_BASE_URL = "https://api-easytravel.jomalang.com"; // EC2 주소

--- a/src/pages/plan/Plan.tsx
+++ b/src/pages/plan/Plan.tsx
@@ -245,8 +245,14 @@ const Plan: React.FC<{ newRequest: boolean }> = ({ newRequest }) => {
 
   // **일정 저장하기 버튼 → 설문 모달 열기**
   const handleSaveClick = async () => {
-    setSurveyModalOpen(true);
+    if (!planId) {
+      setSurveyModalOpen(true);}
+    else{
+      setModalOpen(true);
+    } 
+    
   };
+
 
   // **설문 모달에서 제출 시 설문 저장 + 일정 저장**
   const handleSurveySubmit = async (rating: number, comment: string) => {
@@ -255,7 +261,7 @@ const Plan: React.FC<{ newRequest: boolean }> = ({ newRequest }) => {
       // 1) 설문 API 호출 (예시)
       await axios.post(
         `${API_BASE_URL}/survey`,
-        { rating, comment },
+        { rating, comment,plan_id:planId },
         { withCredentials: true }
       );
 


### PR DESCRIPTION
### 주요 변경 사항
1. 설문 모달 표시 조건 변경
   - planId가 없는(새 일정) 경우에만 설문 모달이 뜨도록 분기 처리
   - planId가 이미 존재하는 일정은 바로 저장(ConfirmModal)로 연결

2. UI 흐름 개선
   - 최초 일정 생성 시 설문 모달 → 일정 저장
   - 이후 수정 시 설문 스킵


